### PR TITLE
Center “Más vendido” text in pricing container

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -389,7 +389,6 @@ button{
         width: 100%;
         height: 40px;
         background-color: #4B164C;
-        display: flex;
         justify-content: center;
         align-items: center;
         border-bottom-left-radius: 100%;
@@ -397,6 +396,8 @@ button{
         & p{
             color: white;
             font-size: 25px;
+            text-align: center;
+            margin-top: 3px;
         }
     }
 


### PR DESCRIPTION
This pull request centers the "Más vendido" text inside the `.vendido` container in the pricing section. The goal is to improve visual alignment and consistency with the rest of the layout.

### Changes made:
- Removed `display: flex` from `.vendido` to avoid conflicting layout behavior.
- Applied `text-align: center` and `margin-top: 3px` to the inner `<p>` element for better vertical alignment.